### PR TITLE
Hardware based sampling limited due to VM nature of GH runner

### DIFF
--- a/docker/platypus/Dockerfile
+++ b/docker/platypus/Dockerfile
@@ -25,24 +25,24 @@ RUN git checkout $build_git_sha
 WORKDIR /$WORKDIR/platypus
 RUN make -j$compile_cores coverage=$coverage
 
-# Build Platypus docs
-WORKDIR /$WORKDIR/platypus
-RUN make -j$compile_cores
-RUN doxygen doc/content/doxygen/Doxyfile
-WORKDIR /$WORKDIR/platypus/doc
-RUN ./moosedocs.py build
+# # Build Platypus docs
+# WORKDIR /$WORKDIR/platypus
+# RUN make -j$compile_cores
+# RUN doxygen doc/content/doxygen/Doxyfile
+# WORKDIR /$WORKDIR/platypus/doc
+# RUN ./moosedocs.py build
 
-# Test Platypus regression tests
-WORKDIR /$WORKDIR/platypus 
-RUN make test linkcoverage=$coverage
+# # Test Platypus regression tests
+# WORKDIR /$WORKDIR/platypus 
+# RUN make test linkcoverage=$coverage
 
-# Build Platypus unit tests
-WORKDIR /$WORKDIR/platypus/unit
-RUN make -j$compile_cores coverage=$coverage
+# # Build Platypus unit tests
+# WORKDIR /$WORKDIR/platypus/unit
+# RUN make -j$compile_cores coverage=$coverage
 
-# Test Platypus unit tests
-WORKDIR /$WORKDIR/platypus/unit
-RUN make test linkcoverage=$coverage
+# # Test Platypus unit tests
+# WORKDIR /$WORKDIR/platypus/unit
+# RUN make test linkcoverage=$coverage
 
 # Setup and Install Intel VTune (can be moved to deps image)
 RUN apt-get update && apt-get upgrade -y && \

--- a/docker/platypus/Dockerfile
+++ b/docker/platypus/Dockerfile
@@ -55,8 +55,9 @@ RUN echo "deb [signed-by=/usr/share/keyrings/intel-oneapi-archive-keyring.gpg] h
 
 RUN apt-get update && apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ca-certificates build-essential pkg-config gnupg libarchive13 openssh-server openssh-client wget net-tools git intel-oneapi-vtune  && \
+    ca-certificates build-essential pkg-config gnupg libarchive13 openssh-server openssh-client wget net-tools git intel-oneapi-vtune kmod && \
     rm -rf /var/lib/apt/lists/*
+
 
 # Run Intel VTune static code analysis on regression tests
 WORKDIR /$WORKDIR/intel/oneapi

--- a/scripts/run-vtune-analysis.sh
+++ b/scripts/run-vtune-analysis.sh
@@ -8,19 +8,21 @@ resultsDir=/opt/platypus/vtune-results
 regressionTestDir=/opt/platypus/test/tests/kernels
 analysisType="hotspots"
 
-cd $regressionTestDir || exit 1
-shopt -s nullglob
-for inputFile in $regressionTestDir/*.i; do
-    testName="$(basename "$inputFile" .${inputFile##*.})"
+. /opt/intel/oneapi/vtune/latest/bin64/vtune-self-checker.sh
+
+# cd $regressionTestDir || exit 1
+# shopt -s nullglob
+# for inputFile in $regressionTestDir/*.i; do
+#     testName="$(basename "$inputFile" .${inputFile##*.})"
     
-    echo "------------------------------------------------------------------"
-    echo "Running Intel VTune $analysisType on $testName regression test" 
-    echo "------------------------------------------------------------------"
+#     echo "------------------------------------------------------------------"
+#     echo "Running Intel VTune $analysisType on $testName regression test" 
+#     echo "------------------------------------------------------------------"
 
-    cd $resultsDir
-    vtune -collect hotspots -strategy=:trace:trace -result-dir="$resultsDir/$testName" /opt/platypus/platypus-opt -i $inputFile
-    vtune -report summary -r "$resultsDir/$testName" -format=html > "${testName}_${analysisType}_summary.html"
-    tar -cvf "${testName}_${analysisType}_results".tar $testName 
-done
+#     cd $resultsDir
+#     vtune -collect hotspots -strategy=:trace:trace -result-dir="$resultsDir/$testName" /opt/platypus/platypus-opt -i $inputFile
+#     vtune -report summary -r "$resultsDir/$testName" -format=html > "${testName}_${analysisType}_summary.html"
+#     tar -cvf "${testName}_${analysisType}_results".tar $testName 
+# done
 
-tar -cvf "regression_test_${analysisType}_summaries.tar" *.html 
+# tar -cvf "regression_test_${analysisType}_summaries.tar" *.html 

--- a/scripts/run-vtune-analysis.sh
+++ b/scripts/run-vtune-analysis.sh
@@ -8,21 +8,20 @@ resultsDir=/opt/platypus/vtune-results
 regressionTestDir=/opt/platypus/test/tests/kernels
 analysisType="hotspots"
 
-. /opt/intel/oneapi/vtune/latest/bin64/vtune-self-checker.sh
 
-# cd $regressionTestDir || exit 1
-# shopt -s nullglob
-# for inputFile in $regressionTestDir/*.i; do
-#     testName="$(basename "$inputFile" .${inputFile##*.})"
+cd $regressionTestDir || exit 1
+shopt -s nullglob
+for inputFile in $regressionTestDir/*.i; do
+    testName="$(basename "$inputFile" .${inputFile##*.})"
     
-#     echo "------------------------------------------------------------------"
-#     echo "Running Intel VTune $analysisType on $testName regression test" 
-#     echo "------------------------------------------------------------------"
+    echo "------------------------------------------------------------------"
+    echo "Running Intel VTune $analysisType on $testName regression test" 
+    echo "------------------------------------------------------------------"
 
-#     cd $resultsDir
-#     vtune -collect hotspots -strategy=:trace:trace -result-dir="$resultsDir/$testName" /opt/platypus/platypus-opt -i $inputFile
-#     vtune -report summary -r "$resultsDir/$testName" -format=html > "${testName}_${analysisType}_summary.html"
-#     tar -cvf "${testName}_${analysisType}_results".tar $testName 
-# done
+    cd $resultsDir
+    vtune -collect hotspots -strategy=:trace:trace -result-dir="$resultsDir/$testName" /opt/platypus/platypus-opt -i $inputFile
+    vtune -report summary -r "$resultsDir/$testName" -format=html > "${testName}_${analysisType}_summary.html"
+    tar -cvf "${testName}_${analysisType}_results".tar $testName 
+done
 
-# tar -cvf "regression_test_${analysisType}_summaries.tar" *.html 
+tar -cvf "regression_test_${analysisType}_summaries.tar" *.html 

--- a/scripts/run-vtune-analysis.sh
+++ b/scripts/run-vtune-analysis.sh
@@ -8,7 +8,8 @@ resultsDir=/opt/platypus/vtune-results
 regressionTestDir=/opt/platypus/test/tests/kernels
 analysisType="hotspots"
 
-. /opt/intel/oneapi/vtune/latest/bin64/vtune-self-checker.sh
+cd /opt/intel/oneapi/vtune/latest/bin64/
+./vtune-self-checker.sh
 
 # cd $regressionTestDir || exit 1
 # shopt -s nullglob


### PR DESCRIPTION
Exploration into enabling more advanced analysis types beyond sampling based profiling have stalled out. As far as I can tell support for running these on a Virtual Machine requires a more in depth setup and enabling of options when setting up that Virtual Machine. As I cannot do this for a github runner I am shelving this idea for now and sticking to improving the workflow which runs sampling based profiling.

More reading here - https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2023-0/on-virtual-machine.html 